### PR TITLE
修复导出数据为空问题

### DIFF
--- a/src/Excel.php
+++ b/src/Excel.php
@@ -259,10 +259,12 @@ class Excel
         if (empty($filename)) {
             $filename = tempnam(sys_get_temp_dir(), 'excel');
         }
-
+        /**
+        * 此处不应有次判断,否则将造成读写不一致。无法正常导出excel文件
         if (strtolower(substr($filename, -5)) != '.xlsx') {
             $filename .= '.xlsx';
         }
+        */
         $writer->writeToFile($filename);
 
         return $filename;


### PR DESCRIPTION
注释临时缓存文件后缀判断，无需此处理。否则导致读写不一致，读取数据为空问题。